### PR TITLE
fix: expire inputs

### DIFF
--- a/.github/workflows/expire.yml
+++ b/.github/workflows/expire.yml
@@ -25,8 +25,12 @@ jobs:
           result-encoding: 'string'
           retries: 3
           script: |-
-            const repoOwner = String('${{ inputs.repo }}').split('/')[0]
-            const repoName = String('${{ inputs.repo }}').split('/')[1]
+            const parts = String('${{ inputs.repo }}').split('/')
+            if (parts.length != 2) {
+              core.setFailed(`Input repo "${{ inputs.repo }}" is not in the right format "<owner>/<name>"`);
+            }
+            const repoOwner = parts[0]
+            const repoName = parts[1]
             const cutoffMs = ${{ inputs.expiryHours }} * 60 * 60 * 1000
             const now = new Date();
             const pulls = await github.rest.pulls.list({

--- a/.github/workflows/expire.yml
+++ b/.github/workflows/expire.yml
@@ -3,12 +3,8 @@ name: 'expire'
 on:
   workflow_call:
     inputs:
-      owner:
-        description: 'The GitHub organization or repository owner.'
-        type: 'string'
-        required: true
       repo:
-        description: 'The repository name.'
+        description: 'The owner and repository name. For example, Codertocat/Hello-World'
         type: 'string'
         required: true
       expiryHours:
@@ -29,11 +25,13 @@ jobs:
           result-encoding: 'string'
           retries: 3
           script: |-
+            const repoOwner = String('${{ inputs.repo }}').split('/')[0]
+            const repoName = String('${{ inputs.repo }}').split('/')[1]
             const cutoffMs = ${{ inputs.expiryHours }} * 60 * 60 * 1000
             const now = new Date();
             const pulls = await github.rest.pulls.list({
-              owner: '${{ inputs.owner }}',
-              repo: '${{ inputs.repo }}',
+              owner: repoOwner,
+              repo: repoName,
               state: 'open',
               per_page: 100,
             });
@@ -46,8 +44,8 @@ jobs:
 
             pulls.data.forEach(async (pull) => {
               const files = await github.rest.pulls.listFiles({
-                owner: '${{ inputs.owner }}',
-                repo: '${{ inputs.repo }}',
+                owner: repoOwner,
+                repo: repoName,
                 pull_number: pull['number'],
               })
 
@@ -64,8 +62,8 @@ jobs:
                 core.info(`Closing #${pull['number']} (${pull['title']})`);
 
                 await github.rest.pulls.update({
-                  owner: '${{ inputs.owner }}',
-                  repo: '${{ inputs.repo }}',
+                  owner: repoOwner,
+                  repo: repoName,
                   pull_number: pull['number'],
                   state: 'closed',
                 });


### PR DESCRIPTION
To use [github.repository context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)(The owner and repository name. For example, octocat/Hello-World.) in the caller workflow, make it easier for caller. 
Below is an example caller
```
  close_pr:
    permissions:
      pull-requests: 'write'
    uses: 'abcxyz/access-on-demand/.github/workflows/expire.yml@main'
    with:
      repo: '${{ github.repository }}'
```