### PR TITLE
fix: referencing github env vars and typo

### DIFF
--- a/.github/workflows/handle.yml
+++ b/.github/workflows/handle.yml
@@ -127,8 +127,8 @@ jobs:
           IAM_FILE_PATH: '${{ github.workspace }}/iam.yaml'
           START_TIME: '${{ github.event.review.submitted_at }}'
         run: |
-          touch $IAM_ERROR_FILENAME
-          aod iam handle -path $IAM_FILE_PATH -duration $DURATION -start-time $START_TIME 2> $IAM_ERROR_FILENAME
+          touch ${{ env.IAM_ERROR_FILENAME }}
+          aod iam handle -path ${{ env.IAM_FILE_PATH }} -duration ${{ env.DURATION }} -start-time ${{ env.START_TIME }} 2> ${{ env.IAM_ERROR_FILENAME }}
       # Request will not be handled when tool.yaml file does not exist in the
       # case of a pull_request_review event, instead it prints out a notice.
       - name: 'Handle CLI Request'
@@ -136,7 +136,7 @@ jobs:
           CLI_FILE_PATH: '${{ github.workspace }}/tool.yaml'
         run: |
           if [ -f "tool.yaml" ]; then
-            aod tool do -path $CLI_FILE_PATH
+            aod tool do -path ${{ env.CLI_FILE_PATH }}
           else
             echo "::notice title=CLI Request Handle::Skip because tool.yaml is not found"
           fi

--- a/.github/workflows/handle.yml
+++ b/.github/workflows/handle.yml
@@ -127,8 +127,8 @@ jobs:
           IAM_FILE_PATH: '${{ github.workspace }}/iam.yaml'
           START_TIME: '${{ github.event.review.submitted_at }}'
         run: |
-          touch ${IAM_ERROR_FILENAME}
-          aod iam handle -path ${FILE_PATH} -duration ${DURATION} -start-time ${START_TIME} 2> ${IAM_ERROR_FILENAME}
+          touch $IAM_ERROR_FILENAME
+          aod iam handle -path $IAM_FILE_PATH -duration $DURATION -start-time $START_TIME 2> $IAM_ERROR_FILENAME
       # Request will not be handled when tool.yaml file does not exist in the
       # case of a pull_request_review event, instead it prints out a notice.
       - name: 'Handle CLI Request'
@@ -136,7 +136,7 @@ jobs:
           CLI_FILE_PATH: '${{ github.workspace }}/tool.yaml'
         run: |
           if [ -f "tool.yaml" ]; then
-            aod tool do -path ${CLI_FILE_PATH}
+            aod tool do -path $CLI_FILE_PATH
           else
             echo "::notice title=CLI Request Handle::Skip because tool.yaml is not found"
           fi


### PR DESCRIPTION
not sure why, but it seems causing args parsing issues see https://github.com/abcxyz/aod-template/actions/runs/5547751120/jobs/10129816341?pr=25


----> found the cause, it not due to ${}, but due to typo...