### PR TITLE
fix: note workflow - remove incorrect and unecessary condition

### DIFF
--- a/.github/workflows/note.yml
+++ b/.github/workflows/note.yml
@@ -33,7 +33,6 @@ jobs:
     name: 'Add AOD Note'
     steps:
       - name: 'Add AOD Note'
-        if: '${{ hashFiles(''iam.yaml'', ''tool.yaml'') != '''' }}'
         uses: 'actions/github-script@98814c53be79b1d30f795b907e553d8679345975' # ratchet:actions/github-script@v6
         with:
           github-token: '${{ github.token }}'


### PR DESCRIPTION
for this condition to work need to checkout the triggering branch. We can add this condition in the triggering workflow instead
```
on:
  pull_request:
    types:
      - 'opened'
    paths:
      - 'iam.yaml'
```