### PR TITLE
feat: add custom condition description for iam handle

### DIFF
--- a/pkg/cli/iam_handle.go
+++ b/pkg/cli/iam_handle.go
@@ -47,8 +47,9 @@ type IAMHandleCommand struct {
 
 	flagVerbose bool
 
-	// flagConditionDescription is required for integration test.
-	flagConditionDescription string
+	// Optional custom condition title for IAM bindings expiration, required for
+	// integration test.
+	flagCustomConditionTitle string
 
 	// testHandler is used for testing only.
 	testHandler iamHandler
@@ -110,11 +111,11 @@ func (c *IAMHandleCommand) Flags() *cli.FlagSet {
 	})
 
 	f.StringVar(&cli.StringVar{
-		Name:    "condition-description",
-		Target:  &c.flagConditionDescription,
+		Name:    "custom-condition-title",
+		Target:  &c.flagCustomConditionTitle,
 		Hidden:  true,
-		Example: "example-description",
-		Usage:   `The description for the aod expiry condition.`,
+		Example: "foo-aod-expiry",
+		Usage:   `The custom title for the aod expiry condition.`,
 	})
 
 	return set
@@ -181,8 +182,8 @@ func (c *IAMHandleCommand) handleIAM(ctx context.Context) error {
 		defer projectsClient.Close()
 
 		var opts []handler.Option
-		if c.flagConditionDescription != "" {
-			opts = append(opts, handler.WithConditionDescription(c.flagConditionDescription))
+		if c.flagCustomConditionTitle != "" {
+			opts = append(opts, handler.WithCustomConditionTitle(c.flagCustomConditionTitle))
 		}
 
 		// Create IAMHandler with the clients.

--- a/pkg/cli/iam_handle.go
+++ b/pkg/cli/iam_handle.go
@@ -47,6 +47,9 @@ type IAMHandleCommand struct {
 
 	flagVerbose bool
 
+	// flagConditionDescription is required for integration test.
+	flagConditionDescription string
+
 	// testHandler is used for testing only.
 	testHandler iamHandler
 }
@@ -104,6 +107,14 @@ func (c *IAMHandleCommand) Flags() *cli.FlagSet {
 		Target:  &c.flagVerbose,
 		Default: false,
 		Usage:   `Turn on verbose mode to print updated IAM policies. Note that it may contain sensitive information`,
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:    "condition-description",
+		Target:  &c.flagConditionDescription,
+		Hidden:  true,
+		Example: "example-description",
+		Usage:   `The description for the aod expiry condition.`,
 	})
 
 	return set
@@ -169,12 +180,18 @@ func (c *IAMHandleCommand) handleIAM(ctx context.Context) error {
 		}
 		defer projectsClient.Close()
 
+		var opts []handler.Option
+		if c.flagConditionDescription != "" {
+			opts = append(opts, handler.WithConditionDescription(c.flagConditionDescription))
+		}
+
 		// Create IAMHandler with the clients.
 		h, err = handler.NewIAMHandler(
 			ctx,
 			organizationsClient,
 			foldersClient,
 			projectsClient,
+			opts...,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create IAM handler: %w", err)

--- a/pkg/handler/iam_handler.go
+++ b/pkg/handler/iam_handler.go
@@ -33,8 +33,8 @@ import (
 )
 
 var (
-	// ConditionTitle of IAM bindings added by AOD.
-	ConditionTitle = "abcxyz-aod-expiry"
+	// defaultConditionTitle of IAM bindings added by AOD.
+	defaultConditionTitle = "abcxyz-aod-expiry"
 	// expirationExpression of IAM binding condition added by AOD.
 	expirationExpression = "request.time < timestamp('%s')"
 	// expirationRegex matching expirationExpression.
@@ -50,6 +50,8 @@ type IAMHandler struct {
 	// Optional retry backoff strategy, default is 5 attempts with fibonacci
 	// backoff that starts at 500ms.
 	retry retry.Backoff
+	// Optional description for IAM bindings expiration condition.
+	conditionDescription string
 }
 
 // IAMClient is the interface to get and set IAM policies for GCP organizations,
@@ -66,6 +68,15 @@ type Option func(h *IAMHandler) (*IAMHandler, error)
 func WithRetry(b retry.Backoff) Option {
 	return func(p *IAMHandler) (*IAMHandler, error) {
 		p.retry = b
+		return p, nil
+	}
+}
+
+// WithConditionDescription provides a condition description for IAM bindings
+// expiration condition.
+func WithConditionDescription(title string) Option {
+	return func(p *IAMHandler) (*IAMHandler, error) {
+		p.conditionDescription = title
 		return p, nil
 	}
 }
@@ -144,7 +155,7 @@ func (h *IAMHandler) handlePolicy(ctx context.Context, p *v1alpha1.ResourcePolic
 		// bindings, however any errors encounterred during removal will be ignored
 		// and policy update for the request will continue. Removal errors should be
 		// handled separately such as in a global IAM cleanup.
-		updatePolicy(ctx, cp, p.Bindings, expiry)
+		h.updatePolicy(ctx, cp, p.Bindings, expiry)
 
 		// Set the new policy.
 		setIAMPolicyRequest := &iampb.SetIamPolicyRequest{
@@ -166,7 +177,7 @@ func (h *IAMHandler) handlePolicy(ctx context.Context, p *v1alpha1.ResourcePolic
 }
 
 // Remove expired bindings and add or update new bindings with expiration condition.
-func updatePolicy(ctx context.Context, p *iampb.Policy, bs []*v1alpha1.Binding, expiry time.Time) {
+func (h *IAMHandler) updatePolicy(ctx context.Context, p *iampb.Policy, bs []*v1alpha1.Binding, expiry time.Time) {
 	logger := logging.FromContext(ctx)
 	// Convert new bindings to a role to unique bindings map.
 	bsMap := toBindingsMap(bs)
@@ -174,7 +185,7 @@ func updatePolicy(ctx context.Context, p *iampb.Policy, bs []*v1alpha1.Binding, 
 	var result []*iampb.Binding
 	for _, cb := range p.Bindings {
 		// Skip non-AOD bindings.
-		if cb.Condition == nil || cb.Condition.Title != ConditionTitle {
+		if cb.Condition == nil || cb.Condition.Title != defaultConditionTitle {
 			result = append(result, cb)
 			continue
 		}
@@ -214,8 +225,9 @@ func updatePolicy(ctx context.Context, p *iampb.Policy, bs []*v1alpha1.Binding, 
 	for r, ms := range bsMap {
 		newBinding := &iampb.Binding{
 			Condition: &expr.Expr{
-				Title:      ConditionTitle,
-				Expression: fmt.Sprintf(expirationExpression, t),
+				Title:       defaultConditionTitle,
+				Expression:  fmt.Sprintf(expirationExpression, t),
+				Description: h.conditionDescription,
 			},
 			Role: r,
 		}

--- a/pkg/handler/iam_handler_test.go
+++ b/pkg/handler/iam_handler_test.go
@@ -45,7 +45,7 @@ func TestDo(t *testing.T) {
 		foldersServer           *fakeServer
 		projectsServer          *fakeServer
 		request                 *v1alpha1.IAMRequestWrapper
-		conditionDescription    string
+		conditionTitle          string
 		wantPolicies            []*v1alpha1.IAMResponse
 		wantErrSubstr           string
 		wantOrganizationsPolicy *iampb.Policy
@@ -210,7 +210,7 @@ func TestDo(t *testing.T) {
 			},
 		},
 		{
-			name: "happy_path_with_condition_description",
+			name: "happy_path_with_custom_condition_title",
 			organizationsServer: &fakeServer{
 				policy: &iampb.Policy{},
 			},
@@ -239,7 +239,7 @@ func TestDo(t *testing.T) {
 				Duration:  2 * time.Hour,
 				StartTime: now,
 			},
-			conditionDescription: "test-description",
+			conditionTitle: "test-aod-expiry-title",
 			wantPolicies: []*v1alpha1.IAMResponse{
 				{
 					Resource: "projects/baz",
@@ -251,9 +251,8 @@ func TestDo(t *testing.T) {
 								},
 								Role: "roles/bigquery.dataViewer",
 								Condition: &expr.Expr{
-									Title:       defaultConditionTitle,
-									Expression:  fmt.Sprintf("request.time < timestamp('%s')", now.Add(2*time.Hour).Format(time.RFC3339)),
-									Description: "test-description",
+									Title:      "test-aod-expiry-title",
+									Expression: fmt.Sprintf("request.time < timestamp('%s')", now.Add(2*time.Hour).Format(time.RFC3339)),
 								},
 							},
 						},
@@ -271,9 +270,8 @@ func TestDo(t *testing.T) {
 						},
 						Role: "roles/bigquery.dataViewer",
 						Condition: &expr.Expr{
-							Title:       defaultConditionTitle,
-							Expression:  fmt.Sprintf("request.time < timestamp('%s')", now.Add(2*time.Hour).Format(time.RFC3339)),
-							Description: "test-description",
+							Title:      "test-aod-expiry-title",
+							Expression: fmt.Sprintf("request.time < timestamp('%s')", now.Add(2*time.Hour).Format(time.RFC3339)),
 						},
 					},
 				},
@@ -1064,8 +1062,8 @@ func TestDo(t *testing.T) {
 			opts := []Option{
 				WithRetry(retry.WithMaxRetries(0, retry.NewFibonacci(500*time.Millisecond))),
 			}
-			if tc.conditionDescription != "" {
-				opts = append(opts, WithConditionDescription(tc.conditionDescription))
+			if tc.conditionTitle != "" {
+				opts = append(opts, WithCustomConditionTitle(tc.conditionTitle))
 			}
 
 			h, err := NewIAMHandler(


### PR DESCRIPTION
In order to do AOD integration test, I compared two approaches, and decided to use 1.

1.  using a unique condition title for integration, the pitfall is that we will need an extra job to cleanup expired bindings as our best effort cleanup only cleanup bindings with the same condition title, I am thinking to use our tool command to do clean up after each integration. 
    - cleanup commd: gcloud projects remove-iam-policy-binding [PROJECT_ID](https://cloud.google.com/sdk/gcloud/reference/projects/remove-iam-policy-binding#PROJECT_ID) [--member](https://cloud.google.com/sdk/gcloud/reference/projects/remove-iam-policy-binding#--member)=PRINCIPAL [--role](https://cloud.google.com/sdk/gcloud/reference/projects/remove-iam-policy-binding#--role)=ROLE [[--all](https://cloud.google.com/sdk/gcloud/reference/projects/remove-iam-policy-binding#--all)     | [--condition](https://cloud.google.com/sdk/gcloud/reference/projects/remove-iam-policy-binding#--condition)=[KEY=VALUE,…] 
2. using unique condition description but the same condition title, we don't need to do extra cleanup, but it won't be able to run integration tests parallelly as AOD will overwrite dup bindings...  