### PR TITLE
chore: add create tag workflow

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,77 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'create_tag'
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The name of the tag to be created.'
+        type: 'string'
+        required: true
+      branch:
+        description: 'The branch of the head commit to create tag on. Default will be the repo default branch.'
+        type: 'string'
+        required: false
+      message:
+        description: 'Message for the tag. Default will be the tag name.'
+        type: 'string'
+        required: false
+      annotated_tag:
+        description: 'This is an annotated tag.'
+        type: 'boolean'
+        default: true
+        required: false
+
+jobs:
+  # This is a workaround to print the inputs for reviewers to review. Reference:
+  # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
+  print-inputs:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'job summary'
+        run: |
+          echo "### Inputs" >> $GITHUB_STEP_SUMMARY
+          echo "- tag: ${{ inputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- branch: ${{ inputs.branch }}" >> $GITHUB_STEP_SUMMARY
+          echo "- annotated tag: ${{ inputs.annotated_tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- message: ${{ inputs.message }}" >> $GITHUB_STEP_SUMMARY
+
+  create_tag:
+    needs: 'print-inputs'
+    permissions:
+      contents: 'write'
+    uses: 'abcxyz/pkg/.github/workflows/create-tag.yml@main' # ratchet:exclude
+    with:
+      tag: '${{ inputs.tag }}'
+      # Set branch and message default here since workflow_dispatch inputs do
+      # not have the access to the context.
+      branch: '${{ inputs.branch || github.event.repository.default_branch }}'
+      message: '${{ inputs.message || inputs.tag }}'
+      annotated_tag: '${{ inputs.annotated_tag }}'
+      deployment_environment: 'tag'
+      token_minter_wif_provider: '${{ vars.TOKEN_MINTER_WIF_PROVIDER }}'
+      token_minter_wif_service_account: '${{ vars.TOKEN_MINTER_WIF_SERVICE_ACCOUNT }}'
+      token_minter_service_audience: '${{ vars.TOKEN_MINTER_SERVICE_AUDIENCE }}'
+      token_minter_service_url: '${{ vars.TOKEN_MINTER_SERVICE_URL }}'
+
+  print-outputs:
+    runs-on: 'ubuntu-latest'
+    needs: 'create_tag'
+    steps:
+      - name: 'job summary'
+        run: |
+          echo "### Outputs" >> $GITHUB_STEP_SUMMARY
+          echo "result: ${{ needs.create_tag.outputs.result }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Create an annotated tag in the repo default branch.
 name: 'create_tag'
 
 on:
@@ -21,18 +22,9 @@ on:
         description: 'The name of the tag to be created.'
         type: 'string'
         required: true
-      branch:
-        description: 'The branch of the head commit to create tag on. Default will be the repo default branch.'
-        type: 'string'
-        required: false
       message:
         description: 'Message for the tag. Default will be the tag name.'
         type: 'string'
-        required: false
-      annotated_tag:
-        description: 'This is an annotated tag.'
-        type: 'boolean'
-        default: true
         required: false
 
 jobs:
@@ -56,11 +48,11 @@ jobs:
     uses: 'abcxyz/pkg/.github/workflows/create-tag.yml@main' # ratchet:exclude
     with:
       tag: '${{ inputs.tag }}'
-      # Set branch and message default here since workflow_dispatch inputs do
-      # not have the access to the context.
-      branch: '${{ inputs.branch || github.event.repository.default_branch }}'
+      branch: '${{ github.event.repository.default_branch }}'
+      # Set message default here since workflow_dispatch inputs do not have the
+      # access to the context.
       message: '${{ inputs.message || inputs.tag }}'
-      annotated_tag: '${{ inputs.annotated_tag }}'
+      annotated_tag: true
       deployment_environment: 'tag'
       token_minter_wif_provider: '${{ vars.TOKEN_MINTER_WIF_PROVIDER }}'
       token_minter_wif_service_account: '${{ vars.TOKEN_MINTER_WIF_SERVICE_ACCOUNT }}'

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,29 +11,22 @@ We leverage [goreleaser](https://goreleaser.com/) for SCM (GitHub) release, see
 ```sh
 go get -u && go mod tidy
 ```
--   Sync to main/HEAD
-```sh
-# Checkout to the main/HEAD
-git checkout main
-```
--   Create a tag using semantic versioning and then push the tag.
-    -   If there are breaking changes, bump the major version
-    -   If there are new major features (but not breaking), bump the minor
-        version
-    -   Nothing important, bump the patch version.
-    -   Feel free to use suffixes -alpha, -beta and -rc as needed
+-   Create a tag using `.github/workflows/create-tag.yml` and run the workflow
+    with below inputs.
 
-```sh
-REL_VER=v0.0.x
-# Tag
-git tag -f -a $REL_VER -m $REL_VER
-# Push tag. This will trigger the release workflow.
-git push origin $REL_VER
-```
+    -   tag name with format `v0.x.x`, using semantic versioning.
+        -   If there are breaking changes, bump the major version.
+        -   If there are new major features (but not breaking), bump the minor
+            version.
+        -   Nothing important, bump the patch version.
+        -   Feel free to use suffixes -alpha, -beta and -rc as needed.
+    -   annotated tag: `true`
+    -   skip to use defaults for branch (repo default branch) and message (tag name).
 
-The new pushed tag should trigger the release workflow which typically does two
-things:
-- Integration test.
-- Create a GitHub release with artifacts (e.g. code zip, binaries,
-etc.). Note: Goreleaser will automatically use the git change log to fill the
-release note.
+-   The new created tag should trigger the release workflow which typically does
+    two things:
+
+    -   Integration test.
+    -   Create a GitHub release with artifacts (e.g. code zip, binaries, etc.).
+        Note: Goreleaser will automatically use the git change log to fill the
+        release note.

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,8 +11,8 @@ We leverage [goreleaser](https://goreleaser.com/) for SCM (GitHub) release, see
 ```sh
 go get -u && go mod tidy
 ```
--   Create a tag using `.github/workflows/create-tag.yml` and run the workflow
-    with below inputs.
+-   Create a tag using `.github/workflows/create-tag.yml` on default branch and
+    run the workflow with below inputs.
 
     -   tag name with format `v0.x.x`, using semantic versioning.
         -   If there are breaking changes, bump the major version.
@@ -20,8 +20,7 @@ go get -u && go mod tidy
             version.
         -   Nothing important, bump the patch version.
         -   Feel free to use suffixes -alpha, -beta and -rc as needed.
-    -   annotated tag: `true`
-    -   skip to use defaults for branch (repo default branch) and message (tag name).
+    -   skip to use default message (tag name).
 
 -   The new created tag should trigger the release workflow which typically does
     two things:


### PR DESCRIPTION
Won't work until pkg and minty change merged

Parallel TODOs
- need to create the `tag` deployment env.
- need to set repo vars for token minter inputs. -> done as they are set at the org level

fix #128 

The workflow page will look similar to (the outputs section result below is fixed):
![image](https://github.com/abcxyz/access-on-demand/assets/51539171/c131862a-286f-40fe-b960-fe793b3b3019)
