### PR TITLE
fix: GH app error and input summary

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -37,14 +37,16 @@ jobs:
         run: |
           echo "### Inputs" >> $GITHUB_STEP_SUMMARY
           echo "- tag: ${{ inputs.tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "- branch: ${{ inputs.branch }}" >> $GITHUB_STEP_SUMMARY
-          echo "- annotated tag: ${{ inputs.annotated_tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "- message: ${{ inputs.message }}" >> $GITHUB_STEP_SUMMARY
+          echo "- branch: ${{ github.event.repository.default_branch }}" >> $GITHUB_STEP_SUMMARY
+          echo "- annotated tag: true" >> $GITHUB_STEP_SUMMARY
+          echo "- message: ${{ inputs.message || inputs.tag }}" >> $GITHUB_STEP_SUMMARY
 
   create_tag:
     needs: 'print-inputs'
     permissions:
-      contents: 'write'
+      # Job need OIDC for token minter to work, see ref:
+      # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+      id-token: 'write'
     uses: 'abcxyz/pkg/.github/workflows/create-tag.yml@main' # ratchet:exclude
     with:
       tag: '${{ inputs.tag }}'


### PR DESCRIPTION
fix error: google-github-actions/auth failed with: `retry function failed after 4 attempts: gitHub Actions did not inject $ACTIONS_ID_TOKEN_REQUEST_TOKEN or $ACTIONS_ID_TOKEN_REQUEST_URL into this job. This most likely means the GitHub Actions workflow permissions are incorrect, or this job is being run from a fork. For more information, please see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token`


link: https://github.com/abcxyz/access-on-demand/actions/runs/6410756716/job/17404732719