### PR TITLE
chore: move job summaries in create-tag to reusable workflow

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -28,21 +28,7 @@ on:
         required: false
 
 jobs:
-  # This is a workaround to print the inputs for reviewers to review. Reference:
-  # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
-  print-inputs:
-    runs-on: 'ubuntu-latest'
-    steps:
-      - name: 'job summary'
-        run: |
-          echo "### Inputs" >> $GITHUB_STEP_SUMMARY
-          echo "- tag: ${{ inputs.tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "- branch: ${{ github.event.repository.default_branch }}" >> $GITHUB_STEP_SUMMARY
-          echo "- annotated tag: true" >> $GITHUB_STEP_SUMMARY
-          echo "- message: ${{ inputs.message || inputs.tag }}" >> $GITHUB_STEP_SUMMARY
-
   create_tag:
-    needs: 'print-inputs'
     permissions:
       # Job need OIDC for token minter to work, see ref:
       # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
@@ -60,12 +46,3 @@ jobs:
       token_minter_wif_service_account: '${{ vars.TOKEN_MINTER_WIF_SERVICE_ACCOUNT }}'
       token_minter_service_audience: '${{ vars.TOKEN_MINTER_SERVICE_AUDIENCE }}'
       token_minter_service_url: '${{ vars.TOKEN_MINTER_SERVICE_URL }}'
-
-  print-outputs:
-    runs-on: 'ubuntu-latest'
-    needs: 'create_tag'
-    steps:
-      - name: 'job summary'
-        run: |
-          echo "### Outputs" >> $GITHUB_STEP_SUMMARY
-          echo "result: ${{ needs.create_tag.outputs.result }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
they are moved in https://github.com/abcxyz/pkg/blob/main/.github/workflows/create-tag.yml#L67