### PR TITLE
feat: add breakglass capabilities

### DIFF
--- a/.github/workflows/handle.yml
+++ b/.github/workflows/handle.yml
@@ -50,9 +50,17 @@ jobs:
     permissions:
       pull-requests: 'read'
     outputs:
-      REVIEW_DECISION: '${{ steps.get_review_decision.outputs.REVIEW_DECISION }}'
+      REVIEW_DECISION: '${{ steps.get_breakglass_decision.outputs.REVIEW_DECISION || steps.get_review_decision.outputs.REVIEW_DECISION }}'
     steps:
+      - id: 'get_breakglass_decision'
+        if: |-
+          contains(github.event.pull_request.labels.*.name, 'aod-breakglass')
+        run: |
+          echo REVIEW_DECISION=BREAKGLASS >> $GITHUB_OUTPUT
+
       - id: 'get_review_decision'
+        if: |-
+          !contains(github.event.pull_request.labels.*.name, 'aod-breakglass')
         env:
           # Set the GH_TOKEN environment variable to use GitHub CLI in a GitHub Actions workflow.
           # See ref: https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows
@@ -74,7 +82,11 @@ jobs:
   handle:
     # Only handle the request when the PR is already approved by qualified approvers.
     needs: 'review_status'
-    if: '${{ needs.review_status.outputs.REVIEW_DECISION == ''APPROVED'' && github.event.review.state == ''approved''}}'
+    if: |-
+      ${{
+        needs.review_status.outputs.REVIEW_DECISION == 'BREAKGLASS' ||
+        (needs.review_status.outputs.REVIEW_DECISION == 'APPROVED' && github.event.review.state == 'approved')
+      }}
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'read'
@@ -89,12 +101,14 @@ jobs:
       # Steps will be skipped starting from here when iam.yaml file does not
       # exist in the case of a pull_request_review event.
       - name: 'Setup Go'
-        if: '${{ hashFiles(''iam.yaml'', ''tool.yaml'') != '''' }}'
+        if: |-
+          ${{ hashFiles('iam.yaml', 'tool.yaml') != '' }}
         uses: 'actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568' # ratchet:actions/setup-go@v3
         with:
           go-version: '${{ inputs.go_version }}'
       - name: 'Authenticate to Google Cloud'
-        if: '${{ hashFiles(''iam.yaml'', ''tool.yaml'') != '''' }}'
+        if: |-
+          ${{ hashFiles('iam.yaml', 'tool.yaml') != '' }}
         uses: 'google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033' # ratchet:google-github-actions/auth@v1
         with:
           workload_identity_provider: '${{ inputs.workload_identity_provider }}'
@@ -102,10 +116,12 @@ jobs:
           token_format: 'access_token'
       # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
       - name: 'Set up Cloud SDK'
-        if: '${{ hashFiles(''tool.yaml'') != '''' }}'
+        if: |-
+          ${{ hashFiles('tool.yaml') != '' }}
         uses: 'google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b' # ratchet:google-github-actions/setup-gcloud@v1
       - name: 'Setup AOD'
-        if: '${{ hashFiles(''iam.yaml'', ''tool.yaml'') != '''' }}'
+        if: |-
+          ${{ hashFiles('iam.yaml', 'tool.yaml') != '' }}
         uses: 'abcxyz/pkg/.github/actions/setup-binary@def8ffd12d32b2e8656152b1eea46017dc8f8eaa' # ratchet:abcxyz/pkg/.github/actions/setup-binary@v0.7.0
         with:
           download_url: 'https://github.com/abcxyz/access-on-demand/releases/download/v${{ inputs.aod_cli_version }}/aod_${{ inputs.aod_cli_version }}_linux_amd64.tar.gz'
@@ -114,7 +130,8 @@ jobs:
           add_to_path: true
       # Duration labels need to be prefixed with "duration-", an example is "duration-2h".
       - name: 'Get Duration From Label'
-        if: '${{ hashFiles(''iam.yaml'') != '''' }}'
+        if: |-
+          ${{ hashFiles('iam.yaml') != '' }}
         run: |
           names='${{ toJson(github.event.pull_request.labels.*.name) }}'
           for name in $(echo "$names" | jq -r '.[]'); do
@@ -126,7 +143,8 @@ jobs:
           done
       # Request will not be handled when iam.yaml file is not found.
       - name: 'Handle IAM Request'
-        if: '${{ hashFiles(''iam.yaml'') != '''' }}'
+        if: |-
+          ${{ hashFiles('iam.yaml') != '' }}
         id: 'handle_iam'
         env:
           DURATION: '${{ env.LABELED_DURATION || env.DEFAULT_DURATION }}'
@@ -143,7 +161,8 @@ jobs:
       # Request will not be handled when tool.yaml file does not exist in the
       # case of a pull_request_review event, instead it prints out a notice.
       - name: 'Handle Tool Request'
-        if: '${{ hashFiles(''tool.yaml'') != '''' }}'
+        if: |-
+          ${{ hashFiles('tool.yaml') != '' }}
         id: 'handle_tool'
         env:
           TOOL_FILE_PATH: '${{ github.workspace }}/tool.yaml'
@@ -154,7 +173,8 @@ jobs:
           1> >(tee ${{ env.TOOL_OUT_FILENAME }})
 
       - name: 'IAM Request Comment'
-        if: '${{ always() && hashFiles(''iam.yaml'') != '''' }}'
+        if: |-
+          ${{ always() && hashFiles('iam.yaml') != '' }}
         uses: 'actions/github-script@98814c53be79b1d30f795b907e553d8679345975' # ratchet:actions/github-script@v6
         with:
           github-token: '${{ github.token }}'
@@ -222,7 +242,8 @@ jobs:
             }
 
       - name: 'Tool Request Comment'
-        if: '${{ always() && hashFiles(''tool.yaml'') != '''' }}'
+        if: |-
+          ${{ always() && hashFiles('tool.yaml') != '' }}
         uses: 'actions/github-script@98814c53be79b1d30f795b907e553d8679345975' # ratchet:actions/github-script@v6
         with:
           github-token: '${{ github.token }}'
@@ -290,7 +311,8 @@ jobs:
             }
 
       - name: 'Request Not Found Comment'
-        if: '${{ always() && hashFiles(''iam.yaml'', ''tool.yaml'') == '''' }}'
+        if: |-
+          ${{ always() && hashFiles('iam.yaml', 'tool.yaml') == '' }}
         uses: 'actions/github-script@98814c53be79b1d30f795b907e553d8679345975' # ratchet:actions/github-script@v6
         with:
           github-token: '${{ github.token }}'

--- a/.github/workflows/note.yml
+++ b/.github/workflows/note.yml
@@ -37,6 +37,14 @@ env:
     <strong>DO NOT</strong> delete the branch manually, the branch will be
     automatically deleted once PR is closed. For more instructions, please see
     [here](${{ inputs.aod_instruction_link }}).
+  AOD_BREAKGLASS_NOTE: >
+    ⛔️ <strong>This is an AOD request, and merging is NOT allowed.</strong>
+    This request is automatically applied since it has been labeled as <strong>`BREAKGLASS`</strong>.
+    Please close the PR once you are finished or it will automatically be closed
+    after ~${{ inputs.expiry_hours }} hours of it's last commit. Please
+    <strong>DO NOT</strong> delete the branch manually, the branch will be
+    automatically deleted once PR is closed. For more instructions, please see
+    [here](${{ inputs.aod_instruction_link }}).
 
 jobs:
   note:
@@ -46,6 +54,8 @@ jobs:
     name: 'Add AOD Note'
     steps:
       - name: 'Add AOD Note'
+        if: |-
+          !contains(github.event.pull_request.labels.*.name, 'aod-breakglass')
         uses: 'actions/github-script@98814c53be79b1d30f795b907e553d8679345975' # ratchet:actions/github-script@v6
         with:
           github-token: '${{ github.token }}'
@@ -56,4 +66,19 @@ jobs:
               repo: context.repo.repo,
               issue_number: ${{ github.event.pull_request.number }},
               body: `${{ env.AOD_NOTE }}`,
+            });
+
+      - name: 'Add AOD Breakglass Note'
+        if: |-
+          contains(github.event.pull_request.labels.*.name, 'aod-breakglass')
+        uses: 'actions/github-script@98814c53be79b1d30f795b907e553d8679345975' # ratchet:actions/github-script@v6
+        with:
+          github-token: '${{ github.token }}'
+          retries: '3'
+          script: |+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.pull_request.number }},
+              body: `${{ env.AOD_BREAKGLASS_NOTE }}`,
             });


### PR DESCRIPTION
This adds the ability to create AoD requests for breakglass scenarios. By adding the `aod-breakglass` label to an AoD pr, it will automatically be applied.

This approach was selected over requiring an issue link as this creates less toil. The justification can be provided in the PR body rather than in a separate issue which just adds an extra step on a separate screen.