### PR TITLE
fix: update note logic

### DIFF
--- a/.github/workflows/note.yml
+++ b/.github/workflows/note.yml
@@ -38,13 +38,7 @@ env:
     automatically deleted once PR is closed. For more instructions, please see
     [here](${{ inputs.aod_instruction_link }}).
   AOD_BREAKGLASS_NOTE: >
-    ⛔️ <strong>This is an AOD request, and merging is NOT allowed.</strong>
-    This request is automatically applied since it has been labeled as <strong>`BREAKGLASS`</strong>.
-    Please close the PR once you are finished or it will automatically be closed
-    after ~${{ inputs.expiry_hours }} hours of it's last commit. Please
-    <strong>DO NOT</strong> delete the branch manually, the branch will be
-    automatically deleted once PR is closed. For more instructions, please see
-    [here](${{ inputs.aod_instruction_link }}).
+    🚨 <strong>This request will be automatically applied since it has been labeled as aod-breakglass</strong>.
 
 jobs:
   note:
@@ -54,8 +48,6 @@ jobs:
     name: 'Add AOD Note'
     steps:
       - name: 'Add AOD Note'
-        if: |-
-          !contains(github.event.pull_request.labels.*.name, 'aod-breakglass')
         uses: 'actions/github-script@98814c53be79b1d30f795b907e553d8679345975' # ratchet:actions/github-script@v6
         with:
           github-token: '${{ github.token }}'


### PR DESCRIPTION
Backticks were causing issue, regardless, this appends a new comment if breakglass is determined. This is useful when a user adds the aod-breakglass label after opening the pull request