### PR TITLE
fix: use pr updated_at for breakglass

### DIFF
--- a/.github/workflows/handle.yml
+++ b/.github/workflows/handle.yml
@@ -149,7 +149,7 @@ jobs:
         env:
           DURATION: '${{ env.LABELED_DURATION || env.DEFAULT_DURATION }}'
           IAM_FILE_PATH: '${{ github.workspace }}/iam.yaml'
-          START_TIME: '${{ github.event.review.submitted_at }}'
+          START_TIME: '${{ github.event.review.submitted_at || github.event.pull_request.updated_at }}'
         run: |
           touch ${{ env.IAM_ERROR_FILENAME }} ${{ env.IAM_OUT_FILENAME }}
           aod iam handle \

--- a/.github/workflows/note.yml
+++ b/.github/workflows/note.yml
@@ -48,6 +48,8 @@ jobs:
     name: 'Add AOD Note'
     steps:
       - name: 'Add AOD Note'
+        if: |-
+          github.event_name == 'pull_request' && github.event.action == 'opened'
         uses: 'actions/github-script@98814c53be79b1d30f795b907e553d8679345975' # ratchet:actions/github-script@v6
         with:
           github-token: '${{ github.token }}'


### PR DESCRIPTION
- Review submitted_at is null if this is for a breakglass label. Use pull_request updated_at instead.
- Restrict AOD note to opened only, this should prevent duplicate comments for the base AOD note