### PR TITLE
Remove shadowed loop variables

### DIFF
--- a/apis/v1alpha1/validation_test.go
+++ b/apis/v1alpha1/validation_test.go
@@ -195,8 +195,6 @@ func TestValidateIAMRequest(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -267,8 +265,6 @@ disallowed command character '&' at 2:21`,
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/cli/iam_cleanup_test.go
+++ b/pkg/cli/iam_cleanup_test.go
@@ -239,8 +239,6 @@ policies:
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/cli/iam_handle_test.go
+++ b/pkg/cli/iam_handle_test.go
@@ -285,8 +285,6 @@ starttime: %s
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/cli/iam_validate_test.go
+++ b/pkg/cli/iam_validate_test.go
@@ -101,8 +101,6 @@ policies:
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/cli/tool_do_test.go
+++ b/pkg/cli/tool_do_test.go
@@ -115,8 +115,6 @@ do:
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/cli/tool_validate_test.go
+++ b/pkg/cli/tool_validate_test.go
@@ -93,8 +93,6 @@ do:
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/handler/iam_handler_test.go
+++ b/pkg/handler/iam_handler_test.go
@@ -1044,8 +1044,6 @@ func TestDo(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1756,8 +1754,6 @@ func TestCleanup(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/handler/tool_handler_test.go
+++ b/pkg/handler/tool_handler_test.go
@@ -115,8 +115,6 @@ test do1`,
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/requestutil/request_test.go
+++ b/pkg/requestutil/request_test.go
@@ -160,8 +160,6 @@ foo: bar
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -251,8 +251,6 @@ gcloud projects list --format json --uri --sort-by=projectId --limit=1
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
This is no longer required as of Go 1.22+
