### PR TITLE
Ratchet pin setup binary v1.4.0

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -121,7 +121,7 @@ jobs:
       - name: 'Setup AOD'
         if: |-
           ${{ hashFiles('iam.yaml') != '' }}
-        uses: 'abcxyz/pkg/.github/actions/setup-binary@6ec157b5c891a6ed2e006ec220f8e00db0e79855' # ratchet:abcxyz/pkg/.github/actions/setup-binary@v1.2.0
+        uses: 'abcxyz/pkg/.github/actions/setup-binary@43bee81badc75711ecc31fde22a14c0cf720704e' # ratchet:abcxyz/pkg/.github/actions/setup-binary@v1.4.0
         with:
           download_url: 'https://github.com/abcxyz/access-on-demand/releases/download/v${{ inputs.aod_cli_version }}/aod_${{ inputs.aod_cli_version }}_linux_amd64.tar.gz'
           install_path: '${{ runner.temp }}/.aod'

--- a/.github/workflows/handle.yml
+++ b/.github/workflows/handle.yml
@@ -122,7 +122,7 @@ jobs:
       - name: 'Setup AOD'
         if: |-
           ${{ hashFiles('iam.yaml', 'tool.yaml') != '' }}
-        uses: 'abcxyz/pkg/.github/actions/setup-binary@6ec157b5c891a6ed2e006ec220f8e00db0e79855' # ratchet:abcxyz/pkg/.github/actions/setup-binary@v1.2.0
+        uses: 'abcxyz/pkg/.github/actions/setup-binary@43bee81badc75711ecc31fde22a14c0cf720704e' # ratchet:abcxyz/pkg/.github/actions/setup-binary@v1.4.0
         with:
           download_url: 'https://github.com/abcxyz/access-on-demand/releases/download/v${{ inputs.aod_cli_version }}/aod_${{ inputs.aod_cli_version }}_linux_amd64.tar.gz'
           install_path: '${{ runner.temp }}/.aod'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,11 +44,11 @@ jobs:
         with:
           ref: '${{ github.event.pull_request.head.ref }}'
       - name: 'Setup Go'
-        uses: 'actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a' # ratchet:actions/setup-go@v5
+        uses: 'actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34' # ratchet:actions/setup-go@v5
         with:
           go-version: '${{ inputs.go_version }}'
       - name: 'Setup AOD'
-        uses: 'abcxyz/pkg/.github/actions/setup-binary@6ec157b5c891a6ed2e006ec220f8e00db0e79855' # ratchet:abcxyz/pkg/.github/actions/setup-binary@v1.2.0
+        uses: 'abcxyz/pkg/.github/actions/setup-binary@43bee81badc75711ecc31fde22a14c0cf720704e' # ratchet:abcxyz/pkg/.github/actions/setup-binary@v1.4.0
         with:
           download_url: 'https://github.com/abcxyz/access-on-demand/releases/download/v${{ inputs.aod_cli_version }}/aod_${{ inputs.aod_cli_version }}_linux_amd64.tar.gz'
           install_path: '${{ runner.temp }}/.aod'


### PR DESCRIPTION
Needed to resolve outdated cache brownout https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down