### PR TITLE
Add permissions to release workflow required by CI integration test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ on:
 # Don't cancel in progress since we don't want to have half-baked release.
 concurrency: '${{ github.workflow }}-${{ github.head_ref || github.ref }}-release'
 
+permissions:
+  contents: 'read'
+  id-token: 'write'
+
 jobs:
   ci:
     uses: 'abcxyz/access-on-demand/.github/workflows/ci.yml@main' # ratchet:exclude


### PR DESCRIPTION
Should fix https://github.com/abcxyz/access-on-demand/actions/runs/13662600846