### PR TITLE
feat: support setting duration from PR tag DURATION

### DIFF
--- a/.github/workflows/handle.yml
+++ b/.github/workflows/handle.yml
@@ -175,7 +175,7 @@ jobs:
           ${{ hashFiles('iam.yaml') != '' }}
         id: 'handle_iam'
         env:
-          DURATION: '${{ env.DURATION || env.LABELED_DURATION || env.DEFAULT_DURATION }}'
+          DURATION: '${{ env.AOD_DURATION || env.LABELED_DURATION || env.DEFAULT_DURATION }}'
           IAM_FILE_PATH: '${{ github.workspace }}/iam.yaml'
           START_TIME: '${{ github.event.review.submitted_at || github.event.pull_request.updated_at }}'
         run: |
@@ -204,6 +204,8 @@ jobs:
         if: |-
           ${{ always() && hashFiles('iam.yaml') != '' }}
         uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7
+        env:
+          DURATION: '${{ env.AOD_DURATION || env.LABELED_DURATION || env.DEFAULT_DURATION }}'
         with:
           github-token: '${{ github.token }}'
           retries: '3'
@@ -222,7 +224,7 @@ jobs:
 
             <details>
             <summary>Details</summary>
-            Added below IAM permissions, and they will be expired in ${{ env.DURATION || env.LABELED_DURATION || env.DEFAULT_DURATION }}.
+            Added below IAM permissions, and they will be expired in ${{ env.DURATION }}.
 
             \`\`\`
             ${req}

--- a/.github/workflows/handle.yml
+++ b/.github/workflows/handle.yml
@@ -36,6 +36,11 @@ on:
         type: 'string'
         default: '1.21'
         required: false
+      tagrep_version:
+        description: 'The version of tagrep to use.'
+        type: 'string'
+        default: '0.0.6'
+        required: false
 
 env:
   DEFAULT_DURATION: '2h'
@@ -129,6 +134,16 @@ jobs:
           cache_key: '${{ runner.os }}_${{ runner.arch }}_aod_${{ inputs.aod_cli_version }}'
           add_to_path: true
           binary_subpath: 'aod'
+      - name: 'Setup Tagrep'
+        if: |-
+          ${{ hashFiles('iam.yaml') != '' }}
+        uses: 'abcxyz/pkg/.github/actions/setup-binary@43bee81badc75711ecc31fde22a14c0cf720704e' # ratchet:abcxyz/pkg/.github/actions/setup-binary@v1.4.0
+        with:
+          download_url: 'https://github.com/abcxyz/tagrep/releases/download/v${{ inputs.tagrep_version }}/tagrep_${{ inputs.tagrep_version }}_linux_amd64.tar.gz'
+          install_path: '${{ runner.temp }}/.tagrep'
+          binary_subpath: 'tagrep'
+          cache_key: '${{ runner.os }}_${{ runner.arch }}_tagrep_${{ inputs.tagrep_version }}'
+          add_to_path: true
       # Duration labels need to be prefixed with "duration-", an example is "duration-2h".
       - name: 'Get Duration From Label'
         if: |-
@@ -142,13 +157,25 @@ jobs:
               break
             fi
           done
+      - name: 'Tagrep PR vars'
+        if: |-
+          ${{ hashFiles('iam.yaml') != '' }}
+        shell: 'bash'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          TAGREP_LOG_TARGET: 'STDERR'
+        run: |
+          tags="$(tagrep parse -type=request -format=raw 2> tagrep.log)"
+          cat tagrep.log
+          echo "tags -> $tags"
+          echo "$tags" >> "$GITHUB_ENV"
       # Request will not be handled when iam.yaml file is not found.
       - name: 'Handle IAM Request'
         if: |-
           ${{ hashFiles('iam.yaml') != '' }}
         id: 'handle_iam'
         env:
-          DURATION: '${{ env.LABELED_DURATION || env.DEFAULT_DURATION }}'
+          DURATION: '${{ env.DURATION || env.LABELED_DURATION || env.DEFAULT_DURATION }}'
           IAM_FILE_PATH: '${{ github.workspace }}/iam.yaml'
           START_TIME: '${{ github.event.review.submitted_at || github.event.pull_request.updated_at }}'
         run: |

--- a/.github/workflows/handle.yml
+++ b/.github/workflows/handle.yml
@@ -222,7 +222,7 @@ jobs:
 
             <details>
             <summary>Details</summary>
-            Added below IAM permissions, and they will be expired in ${{ env.LABELED_DURATION || env.DEFAULT_DURATION }}.
+            Added below IAM permissions, and they will be expired in ${{ env.DURATION || env.LABELED_DURATION || env.DEFAULT_DURATION }}.
 
             \`\`\`
             ${req}


### PR DESCRIPTION
AOD users can now set a PR tag like `DURATION={target_duration}` in their PR description instead of needing to use github labels.

Future work: Deprecate the use of labels for duration. It requires extra steps and provides no additional functionality.