### PR TITLE
fix: downstream failure with chained call to actions/yaml-lint workflow

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -125,7 +125,7 @@ jobs:
       - name: 'Setup AOD'
         if: |-
           ${{ hashFiles('iam.yaml') != '' }}
-        uses: 'abcxyz/actions/.github/actions/setup-binary@f48a2eb5903426eaaa7f565c6a0655813c7f2868' # ratchet:abcxyz/actions/.github/actions/setup-binary@main
+        uses: 'abcxyz/actions/.github/actions/setup-binary@f6b4a8b9931cfcad89e92cda689f548a133428cb' # ratchet:abcxyz/actions/.github/actions/setup-binary@main
         with:
           download_url: 'https://github.com/abcxyz/access-on-demand/releases/download/v${{ inputs.aod_cli_version }}/aod_${{ inputs.aod_cli_version }}_linux_amd64.tar.gz'
           install_path: '${{ runner.temp }}/.aod'

--- a/.github/workflows/handle.yml
+++ b/.github/workflows/handle.yml
@@ -131,7 +131,7 @@ jobs:
       - name: 'Setup AOD'
         if: |-
           ${{ hashFiles('iam.yaml', 'tool.yaml') != '' }}
-        uses: 'abcxyz/actions/.github/actions/setup-binary@f48a2eb5903426eaaa7f565c6a0655813c7f2868' # ratchet:abcxyz/actions/.github/actions/setup-binary@main
+        uses: 'abcxyz/actions/.github/actions/setup-binary@f6b4a8b9931cfcad89e92cda689f548a133428cb' # ratchet:abcxyz/actions/.github/actions/setup-binary@main
         with:
           download_url: 'https://github.com/abcxyz/access-on-demand/releases/download/v${{ inputs.aod_cli_version }}/aod_${{ inputs.aod_cli_version }}_linux_amd64.tar.gz'
           install_path: '${{ runner.temp }}/.aod'
@@ -142,7 +142,7 @@ jobs:
       - name: 'Setup Tagrep'
         if: |-
           ${{ hashFiles('iam.yaml') != '' }}
-        uses: 'abcxyz/actions/.github/actions/setup-binary@f48a2eb5903426eaaa7f565c6a0655813c7f2868' # ratchet:abcxyz/actions/.github/actions/setup-binary@main
+        uses: 'abcxyz/actions/.github/actions/setup-binary@f6b4a8b9931cfcad89e92cda689f548a133428cb' # ratchet:abcxyz/actions/.github/actions/setup-binary@main
         with:
           download_url: 'https://github.com/abcxyz/tagrep/releases/download/v${{ inputs.tagrep_version }}/tagrep_${{ inputs.tagrep_version }}_linux_amd64.tar.gz'
           install_path: '${{ runner.temp }}/.tagrep'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   yaml_lint:
-    uses: 'abcxyz/actions/.github/workflows/yaml-lint.yml@0d3628b4e36a87f4dae37b6a779c46d0995d9af6' # ratchet:exclude
+    uses: 'abcxyz/actions/.github/workflows/yaml-lint.yml@f6b4a8b9931cfcad89e92cda689f548a133428cb' # ratchet:abcxyz/actions/.github/workflows/yaml-lint.yml@main
 
   validate:
     runs-on: 'ubuntu-latest'
@@ -50,7 +50,7 @@ jobs:
           go-version: '${{ inputs.go_version }}'
 
       - name: 'Setup AOD'
-        uses: 'abcxyz/actions/.github/actions/setup-binary@f48a2eb5903426eaaa7f565c6a0655813c7f2868' # ratchet:abcxyz/actions/.github/actions/setup-binary@main
+        uses: 'abcxyz/actions/.github/actions/setup-binary@f6b4a8b9931cfcad89e92cda689f548a133428cb' # ratchet:abcxyz/actions/.github/actions/setup-binary@main
         with:
           download_url: 'https://github.com/abcxyz/access-on-demand/releases/download/v${{ inputs.aod_cli_version }}/aod_${{ inputs.aod_cli_version }}_linux_amd64.tar.gz'
           install_path: '${{ runner.temp }}/.aod'


### PR DESCRIPTION
Migration to `actions` repo references invalid sha for `yaml-lint` workflow. This prevents aod sanity-check.yaml from running causing validation to fail resulting in inability to process AOD request.