### PR TITLE
draft: handle workflow to checkout the approved commit

### DIFF
--- a/.github/workflows/handle.yml
+++ b/.github/workflows/handle.yml
@@ -102,7 +102,7 @@ jobs:
       - name: 'Checkout Triggering Branch'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
         with:
-          ref: '${{ github.event.pull_request.head.ref }}'
+          ref: '${{ github.event.review.commit_id }}'
 
       # Steps will be skipped starting from here when iam.yaml file does not
       # exist in the case of a pull_request_review event.


### PR DESCRIPTION
Although we have recommended users of this repo to enable "Dismiss stale pull request approvals when new commits are pushed" the repo setting (https://github.com/abcxyz/aod-template#prerequisites), with this setting it should guarantee that the event triggering the handle workflow reflects the pull request head ref at the time when the review event is submitted. 

To remove this vulnerability for users who do not enforce the repo setting, use github.event.review.commit_id instead 

However with github.event.review.commit_id, it will break the breakglass feature, where for a breakglass event (pull_request labeled) it does not have github.event.review.